### PR TITLE
Meal fixing

### DIFF
--- a/src/Application/Component/Provider/DishProviderInterface.php
+++ b/src/Application/Component/Provider/DishProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Meals\Application\Component\Provider;
+
+use Meals\Domain\Dish\Dish;
+
+interface DishProviderInterface
+{
+    public function getDish(int $id): Dish;
+}

--- a/src/Application/Component/Provider/PollResultProviderInterface.php
+++ b/src/Application/Component/Provider/PollResultProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Meals\Application\Component\Provider;
+
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+
+interface PollResultProviderInterface
+{
+    public function createNewPollResult(Poll $poll, Employee $employee, Dish $dish): PollResult;
+
+    /**
+     * @return PollResult[]
+     */
+    public function getActivePollResults(): array;
+}

--- a/src/Application/Component/Validator/CanEmployeeCreateNewPollResultValidator.php
+++ b/src/Application/Component/Validator/CanEmployeeCreateNewPollResultValidator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator;
 
 use Assert\Assertion;
@@ -12,9 +11,9 @@ class CanEmployeeCreateNewPollResultValidator
 {
     /**
      * @param PollResult[] $pollResultList
-     * @param Employee     $employee
+     * @param Employee $employee
      */
-    public function validate(array $pollResultList, Employee $employee)
+    public function validate(array $pollResultList, Employee $employee): void
     {
         Assertion::allIsInstanceOf($pollResultList, PollResult::class);
         foreach ($pollResultList as $pollResult) {

--- a/src/Application/Component/Validator/CanEmployeeCreateNewPollResultValidator.php
+++ b/src/Application/Component/Validator/CanEmployeeCreateNewPollResultValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator;
+
+use Assert\Assertion;
+use Meals\Application\Component\Validator\Exception\EmployeeHasAlreadyMadePollResultException;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\PollResult;
+
+class CanEmployeeCreateNewPollResultValidator
+{
+    /**
+     * @param PollResult[] $pollResultList
+     * @param Employee     $employee
+     */
+    public function validate(array $pollResultList, Employee $employee)
+    {
+        Assertion::allIsInstanceOf($pollResultList, PollResult::class);
+        foreach ($pollResultList as $pollResult) {
+            if ($employee->getId() === $pollResult->getEmployee()->getId()) {
+                throw new EmployeeHasAlreadyMadePollResultException();
+            }
+        }
+    }
+}

--- a/src/Application/Component/Validator/DateTimeValidatorCollection.php
+++ b/src/Application/Component/Validator/DateTimeValidatorCollection.php
@@ -19,7 +19,8 @@ class DateTimeValidatorCollection
     public function __construct(
         IsDateTimeMondayValidator $dateTimeMondayValidator,
         IsDateTimeWorkTimeValidator $dateTimeWorkTimeValidator
-    ) {
+    )
+    {
         $this->dateTimeValidators[] = $dateTimeMondayValidator;
         $this->dateTimeValidators[] = $dateTimeWorkTimeValidator;
         // set NOW() by default

--- a/src/Application/Component/Validator/DateTimeValidatorCollection.php
+++ b/src/Application/Component/Validator/DateTimeValidatorCollection.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Meals\Application\Component\Validator;
+
+class DateTimeValidatorCollection
+{
+    /** @var DateTimeValidatorInterface[] */
+    private $dateTimeValidators = [];
+
+    /** @var \DateTimeInterface */
+    private $dateTimeToValidate;
+
+    /**
+     * DateTimeValidatorCollection constructor.
+     *
+     * @param IsDateTimeMondayValidator $dateTimeMondayValidator
+     * @param IsDateTimeWorkTimeValidator $dateTimeWorkTimeValidator
+     */
+    public function __construct(
+        IsDateTimeMondayValidator $dateTimeMondayValidator,
+        IsDateTimeWorkTimeValidator $dateTimeWorkTimeValidator
+    ) {
+        $this->dateTimeValidators[] = $dateTimeMondayValidator;
+        $this->dateTimeValidators[] = $dateTimeWorkTimeValidator;
+        // set NOW() by default
+        $this->setDateTimeToValidate(new \DateTimeImmutable());
+    }
+
+    public function validate(): void
+    {
+        foreach ($this->dateTimeValidators as $validator) {
+            $validator->validate($this->dateTimeToValidate);
+        }
+    }
+
+    public function setDateTimeToValidate(\DateTimeInterface $dateTime): void
+    {
+        $this->dateTimeToValidate = $dateTime;
+    }
+}

--- a/src/Application/Component/Validator/DateTimeValidatorInterface.php
+++ b/src/Application/Component/Validator/DateTimeValidatorInterface.php
@@ -1,10 +1,8 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator;
-
 
 interface DateTimeValidatorInterface
 {
-    public function validate(\DateTimeInterface $dateTime);
+    public function validate(\DateTimeInterface $dateTime): void;
 }

--- a/src/Application/Component/Validator/DateTimeValidatorInterface.php
+++ b/src/Application/Component/Validator/DateTimeValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator;
+
+
+interface DateTimeValidatorInterface
+{
+    public function validate(\DateTimeInterface $dateTime);
+}

--- a/src/Application/Component/Validator/DishIncludedInDishListValidator.php
+++ b/src/Application/Component/Validator/DishIncludedInDishListValidator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Meals\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\DishNotIncludedInDshListException;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Dish\DishList;
+
+class DishIncludedInDishListValidator
+{
+    public function validate(DishList $dishList, Dish $dish)
+    {
+        if (!$dishList->hasDish($dish)) {
+            throw new DishNotIncludedInDshListException();
+        }
+    }
+}

--- a/src/Application/Component/Validator/Exception/DateTimeIsNotAMondayException.php
+++ b/src/Application/Component/Validator/Exception/DateTimeIsNotAMondayException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator\Exception;
+
+
+class DateTimeIsNotAMondayException extends \RuntimeException
+{
+}

--- a/src/Application/Component/Validator/Exception/DateTimeIsNotAMondayException.php
+++ b/src/Application/Component/Validator/Exception/DateTimeIsNotAMondayException.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator\Exception;
-
 
 class DateTimeIsNotAMondayException extends \RuntimeException
 {

--- a/src/Application/Component/Validator/Exception/DateTimeIsNotWorkTimeException.php
+++ b/src/Application/Component/Validator/Exception/DateTimeIsNotWorkTimeException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator\Exception;
+
+
+class DateTimeIsNotWorkTimeException extends \RuntimeException
+{
+
+}

--- a/src/Application/Component/Validator/Exception/DateTimeIsNotWorkTimeException.php
+++ b/src/Application/Component/Validator/Exception/DateTimeIsNotWorkTimeException.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator\Exception;
-
 
 class DateTimeIsNotWorkTimeException extends \RuntimeException
 {
-
 }

--- a/src/Application/Component/Validator/Exception/DishNotIncludedInDshListException.php
+++ b/src/Application/Component/Validator/Exception/DishNotIncludedInDshListException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Meals\Application\Component\Validator\Exception;
+
+class DishNotIncludedInDshListException extends \RuntimeException
+{
+}

--- a/src/Application/Component/Validator/Exception/EmployeeHasAlreadyMadePollResultException.php
+++ b/src/Application/Component/Validator/Exception/EmployeeHasAlreadyMadePollResultException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator\Exception;
+
+
+class EmployeeHasAlreadyMadePollResultException extends \RuntimeException
+{
+}

--- a/src/Application/Component/Validator/Exception/EmployeeHasAlreadyMadePollResultException.php
+++ b/src/Application/Component/Validator/Exception/EmployeeHasAlreadyMadePollResultException.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator\Exception;
-
 
 class EmployeeHasAlreadyMadePollResultException extends \RuntimeException
 {

--- a/src/Application/Component/Validator/IsDateTimeMondayValidator.php
+++ b/src/Application/Component/Validator/IsDateTimeMondayValidator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Meals\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotAMondayException;
+
+class IsDateTimeMondayValidator implements DateTimeValidatorInterface
+{
+    /**
+     * @param \DateTimeInterface $dateTime
+     */
+    public function validate(\DateTimeInterface $dateTime)
+    {
+        if ('Mon' !== $dateTime->format('D')) {
+            throw new DateTimeIsNotAMondayException();
+        }
+    }
+}

--- a/src/Application/Component/Validator/IsDateTimeMondayValidator.php
+++ b/src/Application/Component/Validator/IsDateTimeMondayValidator.php
@@ -9,7 +9,7 @@ class IsDateTimeMondayValidator implements DateTimeValidatorInterface
     /**
      * @param \DateTimeInterface $dateTime
      */
-    public function validate(\DateTimeInterface $dateTime)
+    public function validate(\DateTimeInterface $dateTime): void
     {
         if ('Mon' !== $dateTime->format('D')) {
             throw new DateTimeIsNotAMondayException();

--- a/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
+++ b/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
@@ -7,7 +7,7 @@ use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeExcepti
 class IsDateTimeWorkTimeValidator implements DateTimeValidatorInterface
 {
     const SIX_AM = 60000;
-    const TEN_PM = 220000;
+    const TEN_PM = 215959;
 
     /**
      * @param \DateTimeInterface $dateTime

--- a/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
+++ b/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;
+
+class IsDateTimeWorkTimeValidator implements DateTimeValidatorInterface
+{
+    const SIX_AM = 60000;
+    const TEN_PM = 220000;
+
+    /**
+     * @param \DateTimeInterface $dateTime
+     */
+    public function validate(\DateTimeInterface $dateTime)
+    {
+        // format time '03:12:56 '-> '031256', casting to Int '031256' -> 31256
+        $currentTimeInt = (int) $dateTime->format('His');
+        if (self::SIX_AM > $currentTimeInt || self::TEN_PM < $currentTimeInt) {
+            throw new DateTimeIsNotWorkTimeException();
+        }
+    }
+}

--- a/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
+++ b/src/Application/Component/Validator/IsDateTimeWorkTimeValidator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator;
 
 use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;
@@ -13,10 +12,10 @@ class IsDateTimeWorkTimeValidator implements DateTimeValidatorInterface
     /**
      * @param \DateTimeInterface $dateTime
      */
-    public function validate(\DateTimeInterface $dateTime)
+    public function validate(\DateTimeInterface $dateTime): void
     {
         // format time '03:12:56 '-> '031256', casting to Int '031256' -> 31256
-        $currentTimeInt = (int) $dateTime->format('His');
+        $currentTimeInt = (int)$dateTime->format('His');
         if (self::SIX_AM > $currentTimeInt || self::TEN_PM < $currentTimeInt) {
             throw new DateTimeIsNotWorkTimeException();
         }

--- a/src/Application/Component/Validator/UserAccessToPollsValidatorInterface.php
+++ b/src/Application/Component/Validator/UserAccessToPollsValidatorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Meals\Application\Component\Validator;
+
+use Meals\Domain\User\User;
+
+interface UserAccessToPollsValidatorInterface
+{
+    public function validate(User $user): void;
+}

--- a/src/Application/Component/Validator/UserAccessToPollsValidatorInterface.php
+++ b/src/Application/Component/Validator/UserAccessToPollsValidatorInterface.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator;
 
 use Meals\Domain\User\User;

--- a/src/Application/Component/Validator/UserHasAccessToParticipatePollsValidator.php
+++ b/src/Application/Component/Validator/UserHasAccessToParticipatePollsValidator.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Meals\Application\Component\Validator;
-
 
 use Meals\Application\Component\Validator\Exception\AccessDeniedException;
 use Meals\Domain\User\Permission\Permission;

--- a/src/Application/Component/Validator/UserHasAccessToParticipatePollsValidator.php
+++ b/src/Application/Component/Validator/UserHasAccessToParticipatePollsValidator.php
@@ -1,16 +1,18 @@
 <?php
 
+
 namespace Meals\Application\Component\Validator;
+
 
 use Meals\Application\Component\Validator\Exception\AccessDeniedException;
 use Meals\Domain\User\Permission\Permission;
 use Meals\Domain\User\User;
 
-class UserHasAccessToViewPollsValidator implements UserAccessToPollsValidatorInterface
+class UserHasAccessToParticipatePollsValidator implements UserAccessToPollsValidatorInterface
 {
     public function validate(User $user): void
     {
-        if (!$user->getPermissions()->hasPermission(new Permission(Permission::VIEW_ACTIVE_POLLS))) {
+        if (!$user->getPermissions()->hasPermission(new Permission(Permission::PARTICIPATION_IN_POLLS))) {
             throw new AccessDeniedException();
         }
     }

--- a/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
+++ b/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
@@ -97,14 +97,6 @@ class Interactor
     }
 
     /**
-     * @return DateTimeValidatorCollection
-     */
-    public function getDateTimeValidatorCollection(): DateTimeValidatorCollection
-    {
-        return $this->dateTimeValidatorCollection;
-    }
-
-    /**
      * @param DateTimeValidatorCollection $dateTimeValidatorCollection
      */
     public function setDateTimeValidatorCollection(DateTimeValidatorCollection $dateTimeValidatorCollection): void

--- a/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
+++ b/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
@@ -67,7 +67,8 @@ class Interactor
         DishIncludedInDishListValidator $dishInDishListValidator,
         UserHasAccessToParticipatePollsValidator $userHasAccessToParticipatePollsValidator,
         PollIsActiveValidator $pollIsActiveValidator
-    ) {
+    )
+    {
         $this->dishProvider = $dishProvider;
         $this->employeeProvider = $employeeProvider;
         $this->pollProvider = $pollProvider;
@@ -86,15 +87,10 @@ class Interactor
         $dish = $this->dishProvider->getDish($dishId);
         $activePollResults = $this->pollResultProvider->getActivePollResults();
 
-        // плохое время для метода •
         $this->dateTimeValidatorCollection->validate();
-        // нет прав •
         $this->userHasAccessToParticipatePollsValidator->validate($employee->getUser());
-        // пользователь уже создавал заказ •
         $this->canEmployeeCreateNewPollResultValidator->validate($activePollResults, $employee);
-        // Опрос не активен •
         $this->pollIsActiveValidator->validate($poll);
-        // Выбрано кривое блюда
         $this->dishInDishListValidator->validate($poll->getMenu()->getDishes(), $dish);
 
         return $this->pollResultProvider->createNewPollResult($poll, $employee, $dish);

--- a/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
+++ b/src/Application/Feature/Poll/UseCase/EmployeeSaveActivePoll/Interactor.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Meals\Application\Feature\Poll\UseCase\EmployeeSaveActivePoll;
+
+use Meals\Application\Component\Provider\DishProviderInterface;
+use Meals\Application\Component\Provider\EmployeeProviderInterface;
+use Meals\Application\Component\Provider\PollProviderInterface;
+use Meals\Application\Component\Provider\PollResultProviderInterface;
+use Meals\Application\Component\Validator\CanEmployeeCreateNewPollResultValidator;
+use Meals\Application\Component\Validator\DateTimeValidatorCollection;
+use Meals\Application\Component\Validator\DishIncludedInDishListValidator;
+use Meals\Application\Component\Validator\PollIsActiveValidator;
+use Meals\Application\Component\Validator\UserHasAccessToParticipatePollsValidator;
+use Meals\Domain\Poll\PollResult;
+
+class Interactor
+{
+    // providers
+    /** @var DishProviderInterface */
+    private $dishProvider;
+
+    /** @var EmployeeProviderInterface */
+    private $employeeProvider;
+
+    /** @var PollProviderInterface */
+    private $pollProvider;
+
+    /** @var PollResultProviderInterface */
+    private $pollResultProvider;
+
+    // validators
+    /** @var CanEmployeeCreateNewPollResultValidator */
+    private $canEmployeeCreateNewPollResultValidator;
+
+    /** @var DateTimeValidatorCollection */
+    private $dateTimeValidatorCollection;
+
+    /** @var DishIncludedInDishListValidator */
+    private $dishInDishListValidator;
+
+    /** @var UserHasAccessToParticipatePollsValidator */
+    private $userHasAccessToParticipatePollsValidator;
+
+    /** @var PollIsActiveValidator */
+    private $pollIsActiveValidator;
+
+    /**
+     * Interactor constructor.
+     *
+     * @param DishProviderInterface $dishProvider
+     * @param EmployeeProviderInterface $employeeProvider
+     * @param PollProviderInterface $pollProvider
+     * @param PollResultProviderInterface $pollResultProvider
+     * @param CanEmployeeCreateNewPollResultValidator $canEmployeeCreateNewPollResultValidator
+     * @param DateTimeValidatorCollection $dateTimeValidatorCollection
+     * @param DishIncludedInDishListValidator $dishInDishListValidator
+     * @param UserHasAccessToParticipatePollsValidator $userHasAccessToParticipatePollsValidator
+     * @param PollIsActiveValidator $pollIsActiveValidator
+     */
+    public function __construct(
+        DishProviderInterface $dishProvider,
+        EmployeeProviderInterface $employeeProvider,
+        PollProviderInterface $pollProvider,
+        PollResultProviderInterface $pollResultProvider,
+        CanEmployeeCreateNewPollResultValidator $canEmployeeCreateNewPollResultValidator,
+        DateTimeValidatorCollection $dateTimeValidatorCollection,
+        DishIncludedInDishListValidator $dishInDishListValidator,
+        UserHasAccessToParticipatePollsValidator $userHasAccessToParticipatePollsValidator,
+        PollIsActiveValidator $pollIsActiveValidator
+    ) {
+        $this->dishProvider = $dishProvider;
+        $this->employeeProvider = $employeeProvider;
+        $this->pollProvider = $pollProvider;
+        $this->pollResultProvider = $pollResultProvider;
+        $this->canEmployeeCreateNewPollResultValidator = $canEmployeeCreateNewPollResultValidator;
+        $this->dateTimeValidatorCollection = $dateTimeValidatorCollection;
+        $this->dishInDishListValidator = $dishInDishListValidator;
+        $this->userHasAccessToParticipatePollsValidator = $userHasAccessToParticipatePollsValidator;
+        $this->pollIsActiveValidator = $pollIsActiveValidator;
+    }
+
+    public function saveActivePoll(int $employeeId, int $pollId, int $dishId): PollResult
+    {
+        $employee = $this->employeeProvider->getEmployee($employeeId);
+        $poll = $this->pollProvider->getPoll($pollId);
+        $dish = $this->dishProvider->getDish($dishId);
+        $activePollResults = $this->pollResultProvider->getActivePollResults();
+
+        // плохое время для метода •
+        $this->dateTimeValidatorCollection->validate();
+        // нет прав •
+        $this->userHasAccessToParticipatePollsValidator->validate($employee->getUser());
+        // пользователь уже создавал заказ •
+        $this->canEmployeeCreateNewPollResultValidator->validate($activePollResults, $employee);
+        // Опрос не активен •
+        $this->pollIsActiveValidator->validate($poll);
+        // Выбрано кривое блюда
+        $this->dishInDishListValidator->validate($poll->getMenu()->getDishes(), $dish);
+
+        return $this->pollResultProvider->createNewPollResult($poll, $employee, $dish);
+    }
+
+    /**
+     * @return DateTimeValidatorCollection
+     */
+    public function getDateTimeValidatorCollection(): DateTimeValidatorCollection
+    {
+        return $this->dateTimeValidatorCollection;
+    }
+
+    /**
+     * @param DateTimeValidatorCollection $dateTimeValidatorCollection
+     */
+    public function setDateTimeValidatorCollection(DateTimeValidatorCollection $dateTimeValidatorCollection): void
+    {
+        $this->dateTimeValidatorCollection = $dateTimeValidatorCollection;
+    }
+}

--- a/tests/Functional/Fake/Provider/FakeDishProvider.php
+++ b/tests/Functional/Fake/Provider/FakeDishProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace tests\Meals\Functional\Fake\Provider;
+
+use Meals\Application\Component\Provider\DishProviderInterface;
+use Meals\Domain\Dish\Dish;
+
+class FakeDishProvider implements DishProviderInterface
+{
+    /** @var Dish */
+    private $dish;
+
+    public function getDish(int $id): Dish
+    {
+        return $this->dish;
+    }
+
+    /**
+     * @param Dish $dish
+     */
+    public function setDish(Dish $dish): void
+    {
+        $this->dish = $dish;
+    }
+}

--- a/tests/Functional/Fake/Provider/FakePollResultProvider.php
+++ b/tests/Functional/Fake/Provider/FakePollResultProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace tests\Meals\Functional\Fake\Provider;
+
+use Assert\Assertion;
+use Meals\Application\Component\Provider\PollResultProviderInterface;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+
+class FakePollResultProvider implements PollResultProviderInterface
+{
+    /** @var PollResult[] */
+    private $pollResultList = [];
+
+    public function createNewPollResult(Poll $poll, Employee $employee, Dish $dish): PollResult
+    {
+        return new PollResult(1, $poll, $employee, $dish, $employee->getFloor());
+    }
+
+    public function getActivePollResults(): array
+    {
+        return $this->pollResultList;
+    }
+
+    /**
+     * @param PollResult[] $pollResultList
+     */
+    public function setPollResultList(array $pollResultList): void
+    {
+        Assertion::allIsInstanceOf($pollResultList,PollResult::class);
+        $this->pollResultList = $pollResultList;
+    }
+}

--- a/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
+++ b/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\Meals\Functional\Interactor;
 
+use Meals\Application\Component\Validator\DateTimeValidatorCollection;
 use Meals\Application\Component\Validator\Exception\AccessDeniedException;
 use Meals\Application\Component\Validator\Exception\DateTimeIsNotAMondayException;
 use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;
@@ -152,7 +153,7 @@ class EmployeeSaveActivePollTest extends FunctionalTestCase
 
         /** @var Interactor $interactor */
         $interactor = $this->getContainer()->get(Interactor::class);
-        $dateTimeConstraint = $interactor->getDateTimeValidatorCollection();
+        $dateTimeConstraint = $this->getContainer()->get(DateTimeValidatorCollection::class);
         $dateTimeConstraint->setDateTimeToValidate($timeOfRequest);
         $interactor->setDateTimeValidatorCollection($dateTimeConstraint);
 

--- a/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
+++ b/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace tests\Meals\Functional\Interactor;
+
+use Meals\Application\Component\Validator\Exception\AccessDeniedException;
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotAMondayException;
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;
+use Meals\Application\Component\Validator\Exception\DishNotIncludedInDshListException;
+use Meals\Application\Component\Validator\Exception\EmployeeHasAlreadyMadePollResultException;
+use Meals\Application\Component\Validator\Exception\PollIsNotActiveException;
+use Meals\Application\Feature\Poll\UseCase\EmployeeSaveActivePoll\Interactor;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Dish\DishList;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Menu\Menu;
+use Meals\Domain\Poll\Poll;
+use Meals\Domain\Poll\PollResult;
+use Meals\Domain\User\Permission\Permission;
+use Meals\Domain\User\Permission\PermissionList;
+use Meals\Domain\User\User;
+use tests\Meals\Functional\Fake\Provider\FakeDishProvider;
+use tests\Meals\Functional\Fake\Provider\FakeEmployeeProvider;
+use tests\Meals\Functional\Fake\Provider\FakePollProvider;
+use tests\Meals\Functional\Fake\Provider\FakePollResultProvider;
+use tests\Meals\Functional\FunctionalTestCase;
+
+class EmployeeSaveActivePollTest extends FunctionalTestCase
+{
+    public function testSuccessful()
+    {
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getPoll(),
+            self::getDishIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getCorrectMonday()
+        );
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testUserDoesNotHavePermissions()
+    {
+        $this->expectException(AccessDeniedException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithNoPermissions(),
+            self::getPoll(),
+            self::getDishIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getCorrectMonday()
+        );
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testPollIsNotActive()
+    {
+        $this->expectException(PollIsNotActiveException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getInactivePoll(),
+            self::getDishIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getCorrectMonday()
+        );
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testBlockedDoeNotMondayConstraint()
+    {
+        $this->expectException(DateTimeIsNotAMondayException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getPoll(),
+            self::getDishIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getCorrectFriday()
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testBlockedDueToTimeConstraints()
+    {
+        $this->expectException(DateTimeIsNotWorkTimeException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getPoll(),
+            self::getDishIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getBadMonday()
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testEmployeeHasAlreadyCreatedPollResult()
+    {
+        $this->expectException(EmployeeHasAlreadyMadePollResultException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getPoll(),
+            self::getDishIncludedInMenu(),
+            self::getPollResultWithPoll(),
+            self::getCorrectMonday()
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    public function testDishNotInPollMenu()
+    {
+        $this->expectException(DishNotIncludedInDshListException::class);
+
+        $pollResult = $this->performTestMethod(
+            self::getEmployeeWithPermissions(),
+            self::getPoll(),
+            self::getDishNotIncludedInMenu(),
+            self::getEmptyPollResultList(),
+            self::getCorrectMonday()
+        );
+
+        verify($pollResult)->equals($pollResult);
+    }
+
+    /**
+     * @param Employee $employee
+     * @param Poll $poll
+     * @param Dish $dish
+     * @param PollResult[] $pollResultList
+     * @param \DateTimeInterface $timeOfRequest
+     *
+     * @return PollResult
+     *
+     * @throws \Exception
+     */
+    private function performTestMethod(
+        Employee $employee,
+        Poll $poll,
+        Dish $dish,
+        array $pollResultList,
+        \DateTimeInterface $timeOfRequest
+    ): PollResult {
+        $this->getContainer()->get(FakeEmployeeProvider::class)->setEmployee($employee);
+        $this->getContainer()->get(FakePollProvider::class)->setPoll($poll);
+        $this->getContainer()->get(FakeDishProvider::class)->setDish($dish);
+        $this->getContainer()->get(FakePollResultProvider::class)->setPollResultList($pollResultList);
+
+        /** @var Interactor $interactor */
+        $interactor = $this->getContainer()->get(Interactor::class);
+        $dateTimeConstraint = $interactor->getDateTimeValidatorCollection();
+        $dateTimeConstraint->setDateTimeToValidate($timeOfRequest);
+        $interactor->setDateTimeValidatorCollection($dateTimeConstraint);
+
+        return $interactor->saveActivePoll($employee->getId(), $poll->getId(), $dish->getId());
+    }
+
+    private static function getCorrectMonday(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('first monday'))->setTime(9, 0, 0);
+    }
+
+    private static function getBadMonday(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('first monday'))->setTime(5, 0, 0);
+    }
+
+    private static function getCorrectFriday(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('first friday'))->setTime(9, 0, 0);
+    }
+
+    private static function getEmployeeWithPermissions(): Employee
+    {
+        return new Employee(1, self::getUserWithPermissions(), 4, 'Surname');
+    }
+
+    private static function getEmployeeWithNoPermissions(): Employee
+    {
+        return new Employee(1, self::getUserWithNoPermissions(), 4, 'Surname');
+    }
+
+    private static function getPollResultWithPoll(): array
+    {
+        return [new PollResult(10, self::getPoll(), self::getEmployeeWithPermissions(), self::getDishIncludedInMenu(), 4)];
+    }
+
+    private static function getEmptyPollResultList(): array
+    {
+        return [];
+    }
+
+    private static function getDishIncludedInMenu(): Dish
+    {
+        return new Dish(1, 'Awesome Cutlets', 'Cutlets with mashed potatoes');
+    }
+
+    private static function getDishNotIncludedInMenu(): Dish
+    {
+        return new Dish(2, 'Awful Cutlets', 'Cutlets with pasta');
+    }
+
+
+    private static function getUserWithPermissions(): User
+    {
+        return new User( 1, new PermissionList([new Permission(Permission::PARTICIPATION_IN_POLLS)]));
+    }
+
+    private static function getUserWithNoPermissions(): User
+    {
+        return new User(1, new PermissionList([]));
+    }
+
+    private static function getPoll(): Poll
+    {
+        return new Poll(1, true, new Menu(1, 'title', new DishList([self::getDishIncludedInMenu()])));
+    }
+
+    private static function getInactivePoll(): Poll
+    {
+        return new Poll(1, false, new Menu(1, 'title', new DishList([self::getDishIncludedInMenu()])));
+    }
+}

--- a/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
+++ b/tests/Functional/Interactor/EmployeeSaveActivePollTest.php
@@ -143,7 +143,8 @@ class EmployeeSaveActivePollTest extends FunctionalTestCase
         Dish $dish,
         array $pollResultList,
         \DateTimeInterface $timeOfRequest
-    ): PollResult {
+    ): PollResult
+    {
         $this->getContainer()->get(FakeEmployeeProvider::class)->setEmployee($employee);
         $this->getContainer()->get(FakePollProvider::class)->setPoll($poll);
         $this->getContainer()->get(FakeDishProvider::class)->setDish($dish);
@@ -206,7 +207,7 @@ class EmployeeSaveActivePollTest extends FunctionalTestCase
 
     private static function getUserWithPermissions(): User
     {
-        return new User( 1, new PermissionList([new Permission(Permission::PARTICIPATION_IN_POLLS)]));
+        return new User(1, new PermissionList([new Permission(Permission::PARTICIPATION_IN_POLLS)]));
     }
 
     private static function getUserWithNoPermissions(): User

--- a/tests/Unit/Application/Component/Validator/BaseUserPollAccessValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/BaseUserPollAccessValidatorTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace tests\Meals\Unit\Application\Component\Validator;
-
 
 use Meals\Application\Component\Validator\Exception\AccessDeniedException;
 use Meals\Application\Component\Validator\UserAccessToPollsValidatorInterface;

--- a/tests/Unit/Application/Component/Validator/BaseUserPollAccessValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/BaseUserPollAccessValidatorTest.php
@@ -1,29 +1,33 @@
 <?php
 
+
 namespace tests\Meals\Unit\Application\Component\Validator;
 
+
 use Meals\Application\Component\Validator\Exception\AccessDeniedException;
-use Meals\Application\Component\Validator\UserHasAccessToViewPollsValidator;
-use Meals\Domain\User\Permission\Permission;
+use Meals\Application\Component\Validator\UserAccessToPollsValidatorInterface;
 use Meals\Domain\User\Permission\PermissionList;
 use Meals\Domain\User\User;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
-class UserHasAccessToViewPollsValidatorTest extends TestCase
+abstract class BaseUserPollAccessValidatorTest extends TestCase
 {
     use ProphecyTrait;
+
+    abstract protected function getPermission(): string;
+
+    abstract protected function getValidator(): UserAccessToPollsValidatorInterface;
 
     public function testSuccessful()
     {
         $permissionList = $this->prophesize(PermissionList::class);
-        $permissionList->hasPermission(Permission::VIEW_ACTIVE_POLLS)->willReturn(true);
+        $permissionList->hasPermission($this->getPermission())->willReturn(true);
 
         $user = $this->prophesize(User::class);
         $user->getPermissions()->willReturn($permissionList->reveal());
 
-        $validator = new UserHasAccessToViewPollsValidator();
-        verify($validator->validate($user->reveal()))->null();
+        verify($this->getValidator()->validate($user->reveal()))->null();
     }
 
     public function testFail()
@@ -31,12 +35,11 @@ class UserHasAccessToViewPollsValidatorTest extends TestCase
         $this->expectException(AccessDeniedException::class);
 
         $permissionList = $this->prophesize(PermissionList::class);
-        $permissionList->hasPermission(Permission::VIEW_ACTIVE_POLLS)->willReturn(false);
+        $permissionList->hasPermission($this->getPermission())->willReturn(false);
 
         $user = $this->prophesize(User::class);
         $user->getPermissions()->willReturn($permissionList->reveal());
 
-        $validator = new UserHasAccessToViewPollsValidator();
-        $validator->validate($user->reveal());
+        $this->getValidator()->validate($user->reveal());
     }
 }

--- a/tests/Unit/Application/Component/Validator/CanEmployeeCreateNewPollResultValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/CanEmployeeCreateNewPollResultValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\CanEmployeeCreateNewPollResultValidator;
+use Meals\Application\Component\Validator\Exception\EmployeeHasAlreadyMadePollResultException;
+use Meals\Domain\Employee\Employee;
+use Meals\Domain\Poll\PollResult;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class CanEmployeeCreateNewPollResultValidatorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testSuccessful()
+    {
+        $employee = $this->prophesize(Employee::class);
+        $validationEmployee = $this->prophesize(Employee::class);
+
+        $employee->getId()->willReturn(1);
+        $validationEmployee->getId()->willReturn(2);
+
+        $pollResult = $this->prophesize(PollResult::class);
+        $pollResult->getEmployee()->willReturn($employee->reveal());
+
+        $validator = new CanEmployeeCreateNewPollResultValidator();
+        verify($validator->validate([$pollResult->reveal()], $validationEmployee->reveal()))->null();
+    }
+
+    public function testFail()
+    {
+        $this->expectException(EmployeeHasAlreadyMadePollResultException::class);
+
+        $employee = $this->prophesize(Employee::class);
+        $employee->getId()->willReturn(1);
+
+        $pollResult = $this->prophesize(PollResult::class);
+        $pollResult->getEmployee()->willReturn($employee->reveal());
+
+        $validator = new CanEmployeeCreateNewPollResultValidator();
+        $validator->validate([$pollResult->reveal()], $employee->reveal());
+    }
+}

--- a/tests/Unit/Application/Component/Validator/CanEmployeeCreateNewPollResultValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/CanEmployeeCreateNewPollResultValidatorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace tests\Meals\Unit\Application\Component\Validator;
 
 use Meals\Application\Component\Validator\CanEmployeeCreateNewPollResultValidator;

--- a/tests/Unit/Application/Component/Validator/DishIncludedInDishListValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/DishIncludedInDishListValidatorTest.php
@@ -8,7 +8,6 @@ use Meals\Domain\Dish\Dish;
 use Meals\Domain\Dish\DishList;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 
 class DishIncludedInDishListValidatorTest extends TestCase
 {
@@ -16,11 +15,9 @@ class DishIncludedInDishListValidatorTest extends TestCase
 
     public function testSuccessful()
     {
-        /** @var Dish|ObjectProphecy $dish */
         $dish = $this->prophesize(Dish::class);
-
-        /** @var DishList|ObjectProphecy $dishList */
         $dishList = $this->prophesize(DishList::class);
+
         $dishList->hasDish($dish->reveal())->willReturn(true);
 
         $validator = new DishIncludedInDishListValidator();
@@ -31,11 +28,9 @@ class DishIncludedInDishListValidatorTest extends TestCase
     {
         $this->expectException(DishNotIncludedInDshListException::class);
 
-        /** @var Dish|ObjectProphecy $dish */
         $dish = $this->prophesize(Dish::class);
-
-        /** @var DishList|ObjectProphecy $dishList */
         $dishList = $this->prophesize(DishList::class);
+
         $dishList->hasDish($dish->reveal())->willReturn(false);
 
         $validator = new DishIncludedInDishListValidator();

--- a/tests/Unit/Application/Component/Validator/DishIncludedInDishListValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/DishIncludedInDishListValidatorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\DishIncludedInDishListValidator;
+use Meals\Application\Component\Validator\Exception\DishNotIncludedInDshListException;
+use Meals\Domain\Dish\Dish;
+use Meals\Domain\Dish\DishList;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class DishIncludedInDishListValidatorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testSuccessful()
+    {
+        /** @var Dish|ObjectProphecy $dish */
+        $dish = $this->prophesize(Dish::class);
+
+        /** @var DishList|ObjectProphecy $dishList */
+        $dishList = $this->prophesize(DishList::class);
+        $dishList->hasDish($dish->reveal())->willReturn(true);
+
+        $validator = new DishIncludedInDishListValidator();
+        verify($validator->validate($dishList->reveal(), $dish->reveal()))->null();
+    }
+
+    public function testFail()
+    {
+        $this->expectException(DishNotIncludedInDshListException::class);
+
+        /** @var Dish|ObjectProphecy $dish */
+        $dish = $this->prophesize(Dish::class);
+
+        /** @var DishList|ObjectProphecy $dishList */
+        $dishList = $this->prophesize(DishList::class);
+        $dishList->hasDish($dish->reveal())->willReturn(false);
+
+        $validator = new DishIncludedInDishListValidator();
+        $validator->validate($dishList->reveal(), $dish->reveal());
+    }
+}

--- a/tests/Unit/Application/Component/Validator/IsDateTimeMondayValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/IsDateTimeMondayValidatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotAMondayException;
+use Meals\Application\Component\Validator\IsDateTimeMondayValidator;
+use PHPUnit\Framework\TestCase;
+
+class IsDateTimeMondayValidatorTest extends TestCase
+{
+    public function testSuccessful()
+    {
+        $dateTime = new \DateTimeImmutable('first monday');
+
+        $validator = new IsDateTimeMondayValidator();
+
+        verify($validator->validate($dateTime))->null();
+    }
+
+    public function testFail()
+    {
+        $this->expectException(DateTimeIsNotAMondayException::class);
+
+        $dateTime = new \DateTimeImmutable('first friday');
+        $validator = new IsDateTimeMondayValidator();
+
+        $validator->validate($dateTime);
+    }
+}

--- a/tests/Unit/Application/Component/Validator/IsDateTimeMondayValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/IsDateTimeMondayValidatorTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace tests\Meals\Unit\Application\Component\Validator;
-
 
 use Meals\Application\Component\Validator\Exception\DateTimeIsNotAMondayException;
 use Meals\Application\Component\Validator\IsDateTimeMondayValidator;

--- a/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;
+use Meals\Application\Component\Validator\IsDateTimeWorkTimeValidator;
+use PHPUnit\Framework\TestCase;
+
+class IsDateTimeWorkTimeValidatorTest extends TestCase
+{
+    public function testSuccessful()
+    {
+        $minDateTime = new \DateTimeImmutable('11.11.2011 06:00:00');
+        $maxDateTime = new \DateTimeImmutable('11.11.2011 22:00:00');
+
+        $validator = new IsDateTimeWorkTimeValidator();
+
+        verify($validator->validate($minDateTime))->null();
+        verify($validator->validate($maxDateTime))->null();
+    }
+
+    public function testFail()
+    {
+        $this->expectException(DateTimeIsNotWorkTimeException::class);
+
+        $minDateTime = new \DateTimeImmutable('11.11.2011 05:59:59');
+        $maxDateTime = new \DateTimeImmutable('11.11.2011 22:00:01');
+
+        $validator = new IsDateTimeWorkTimeValidator();
+
+        try {
+            $validator->validate($minDateTime);
+        } catch (DateTimeIsNotWorkTimeException $exception) {
+            $validator->validate($maxDateTime);
+        }
+
+        $this->fail('Exception was not thrown!');
+    }
+}

--- a/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace tests\Meals\Unit\Application\Component\Validator;
 
 use Meals\Application\Component\Validator\Exception\DateTimeIsNotWorkTimeException;

--- a/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/IsDateTimeWorkTimeValidatorTest.php
@@ -11,7 +11,7 @@ class IsDateTimeWorkTimeValidatorTest extends TestCase
     public function testSuccessful()
     {
         $minDateTime = new \DateTimeImmutable('11.11.2011 06:00:00');
-        $maxDateTime = new \DateTimeImmutable('11.11.2011 22:00:00');
+        $maxDateTime = new \DateTimeImmutable('11.11.2011 21:59:59');
 
         $validator = new IsDateTimeWorkTimeValidator();
 
@@ -24,7 +24,7 @@ class IsDateTimeWorkTimeValidatorTest extends TestCase
         $this->expectException(DateTimeIsNotWorkTimeException::class);
 
         $minDateTime = new \DateTimeImmutable('11.11.2011 05:59:59');
-        $maxDateTime = new \DateTimeImmutable('11.11.2011 22:00:01');
+        $maxDateTime = new \DateTimeImmutable('11.11.2011 22:00:00');
 
         $validator = new IsDateTimeWorkTimeValidator();
 

--- a/tests/Unit/Application/Component/Validator/UserHasAccessToParticipatePollsValidatorValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/UserHasAccessToParticipatePollsValidatorValidatorTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace tests\Meals\Unit\Application\Component\Validator;
-
 
 use Meals\Application\Component\Validator\UserAccessToPollsValidatorInterface;
 use Meals\Application\Component\Validator\UserHasAccessToParticipatePollsValidator;

--- a/tests/Unit/Application/Component/Validator/UserHasAccessToParticipatePollsValidatorValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/UserHasAccessToParticipatePollsValidatorValidatorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+
+use Meals\Application\Component\Validator\UserAccessToPollsValidatorInterface;
+use Meals\Application\Component\Validator\UserHasAccessToParticipatePollsValidator;
+use Meals\Domain\User\Permission\Permission;
+
+class UserHasAccessToParticipatePollsValidatorValidatorTest extends BaseUserPollAccessValidatorTest
+{
+    protected function getPermission(): string
+    {
+        return Permission::PARTICIPATION_IN_POLLS;
+    }
+
+    protected function getValidator(): UserAccessToPollsValidatorInterface
+    {
+        return new UserHasAccessToParticipatePollsValidator();
+    }
+}

--- a/tests/Unit/Application/Component/Validator/UserHasAccessToViewPollsValidatorValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/UserHasAccessToViewPollsValidatorValidatorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace tests\Meals\Unit\Application\Component\Validator;
+
+use Meals\Application\Component\Validator\UserAccessToPollsValidatorInterface;
+use Meals\Application\Component\Validator\UserHasAccessToViewPollsValidator;
+use Meals\Domain\User\Permission\Permission;
+
+class UserHasAccessToViewPollsValidatorValidatorTest extends BaseUserPollAccessValidatorTest
+{
+    protected function  getPermission(): string
+    {
+        return Permission::VIEW_ACTIVE_POLLS;
+    }
+
+    protected function getValidator(): UserAccessToPollsValidatorInterface
+    {
+        return new UserHasAccessToViewPollsValidator();
+    }
+}

--- a/tests/Unit/Application/Component/Validator/UserHasAccessToViewPollsValidatorValidatorTest.php
+++ b/tests/Unit/Application/Component/Validator/UserHasAccessToViewPollsValidatorValidatorTest.php
@@ -8,7 +8,7 @@ use Meals\Domain\User\Permission\Permission;
 
 class UserHasAccessToViewPollsValidatorValidatorTest extends BaseUserPollAccessValidatorTest
 {
-    protected function  getPermission(): string
+    protected function getPermission(): string
     {
         return Permission::VIEW_ACTIVE_POLLS;
     }


### PR DESCRIPTION
- Объявлены новые провайдеры
• DishProvider - для получения блюда, по запросу пользователя на сохранение заказа (`function getDish(int $id): Dish`)
• PollResultProvider - для сохранения (`public function createNewPollResult(Poll $poll, Employee $employee, Dish $dish): PollResult`) и получения (`public function getActivePollResults(): PollResult[]`) имеющихся заказов. Сохранение прямо необходимо по  требованиям, получение необходимо для ограничения сохранения заказов (не более 1 заказа на сотрудника).
- Был изменён тест `UserHasAccessToViewPollsValidatorValidatorTest`. Теперь он наследует тест `BaseUserPollAccessValidatorTest`. Это позволяет добавлять больше различных `Permissions` для пользователей, покрывая тестами новые валидаторы быстрее, чем до этого. Логика теста не изменилась.
- В разработке старался по минимуму затрагивать имеющийся код и архитектуру, доменные сущности не затронуты вовсе.

**ps** контейнер отказался собираться без этого фикса: https://github.com/s0p3Nie/test-task-meals/pull/1
_win10_